### PR TITLE
Add missing promo code claim methods required by CLI

### DIFF
--- a/billing_structs.go
+++ b/billing_structs.go
@@ -55,6 +55,55 @@ func (m *PromoCodeClaim) Reset()         { *m = PromoCodeClaim{} }
 func (m *PromoCodeClaim) String() string { return proto.CompactTextString(m) }
 func (*PromoCodeClaim) ProtoMessage()    {}
 
+func (m *PromoCodeClaim) GetOrgId() int32 {
+	if m != nil {
+		return m.OrgId
+	}
+	return 0
+}
+
+func (m *PromoCodeClaim) GetCode() string {
+	if m != nil {
+		return m.Code
+	}
+	return ""
+}
+
+func (m *PromoCodeClaim) GetAmount() int64 {
+	if m != nil {
+		return m.Amount
+	}
+	return 0
+}
+
+func (m *PromoCodeClaim) GetBalance() int64 {
+	if m != nil {
+		return m.Balance
+	}
+	return 0
+}
+
+func (m *PromoCodeClaim) GetClaimDate() *types.Timestamp {
+	if m != nil {
+		return m.ClaimDate
+	}
+	return nil
+}
+
+func (m *PromoCodeClaim) GetCreditExpirationDate() *types.Timestamp {
+	if m != nil {
+		return m.CreditExpirationDate
+	}
+	return nil
+}
+
+func (m *PromoCodeClaim) GetClaimedBy() int32 {
+	if m != nil {
+		return m.ClaimedBy
+	}
+	return 0
+}
+
 type Card struct {
 	Cardholder           string   `protobuf:"bytes,1,opt,name=cardholder,proto3" json:"cardholder,omitempty" db:"cardholder,omitempty" url:"cardholder,omitempty"`
 	Brand                string   `protobuf:"bytes,2,opt,name=brand,proto3" json:"brand,omitempty" db:"brand,omitempty" url:"brand,omitempty"`

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,6 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
```
internal/cmd/admin/command_promo_list.go:46:22: code.GetCode undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetCode)
internal/cmd/admin/command_promo_list.go:47:46: code.GetBalance undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetBalance)
internal/cmd/admin/command_promo_list.go:48:33: code.GetCreditExpirationDate undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetCreditExpirationDate)
internal/cmd/admin/command_promo_list.go:52:22: code.GetCode undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetCode)
internal/cmd/admin/command_promo_list.go:53:36: code.GetBalance undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetBalance)
internal/cmd/admin/command_promo_list.go:53:55: code.GetAmount undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetAmount)
internal/cmd/admin/command_promo_list.go:54:39: code.GetCreditExpirationDate undefined (type *"github.com/confluentinc/ccloud-sdk-go-v1-public".PromoCodeClaim has no field or method GetCreditExpirationDate)
```