### PR TITLE
INC-779: Add `--unsafe-trace` support

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/dghubble/sling"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -105,7 +104,7 @@ func (c *LoggingHttpClient) Do(req *http.Request) (*http.Response, error) {
 		body := fmt.Sprintf("%s", req.Body)
 		reqLog = fmt.Sprintf("%s Body:%s", reqLog, body[1:len(body)-1])
 	}
-	c.logger.Debug(caller, " ", reqLog)
+	c.logger.UnsafeTrace(caller, " ", reqLog)
 	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -118,7 +117,7 @@ func (c *LoggingHttpClient) Do(req *http.Request) (*http.Response, error) {
 	bufferReader := bytes.NewBuffer(b)
 	res.Body = readCloser{bufferReader, res.Body}
 	resLog := fmt.Sprintf("response: %s X-Request-Id:%s Body: %s", res.Status, res.Header.Get("X-Request-Id"), bufferReader)
-	c.logger.Debug(caller, " ", resLog, " ", reqLog)
+	c.logger.UnsafeTrace(caller, " ", resLog)
 	return res, nil
 }
 
@@ -165,9 +164,6 @@ func setDefaults(p *Params) *Params {
 	}
 	if p.BaseURL == "" {
 		p.BaseURL = "https://confluent.cloud"
-	}
-	if p.Logger == nil {
-		p.Logger = logrus.New()
 	}
 	if p.BaseClient == nil {
 		p.BaseClient = BaseClient

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gogo/googleapis v1.4.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
-	github.com/sirupsen/logrus v1.9.0
 	github.com/travisjeffery/mocker v1.1.0
 	github.com/travisjeffery/proto-go-sql v0.0.0-20190911121832-39ff47280e87
 	github.com/ugorji/go/codec v1.2.8

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
@@ -347,7 +345,6 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/interfaces.go
+++ b/interfaces.go
@@ -71,9 +71,10 @@ type UserInterface interface {
 }
 
 // Logger provides an interface that will be used for all logging in this client. User provided
-// logging implementations must conform to this interface. Popular loggers like zap and logrus
-// already implement this interface.
+// logging implementations must conform to this interface.
 type Logger interface {
+	UnsafeTrace(...interface{})
+	UnsafeTracef(string, ...interface{})
 	Debug(...interface{})
 	Debugf(string, ...interface{})
 	Info(...interface{})


### PR DESCRIPTION
Add support for `--unsafe-trace`, for the purpose of logging HTTP request and response in a secure manner.